### PR TITLE
Final fixes for V29:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [![Build Status](https://travis-ci.org/wolfman2000/stumpy.svg?branch=master)](https://travis-ci.org/wolfman2000/stumpy)
 
-This is version 3.4.0 of the tracker, meant to be inspired by crossproduct's excellent tracker. Please see & support his work at [twitch.tv/crossproduct](https://twitch.tv/crossproduct).
+This is version 3.5.0 of the tracker, meant to be inspired by crossproduct's excellent tracker. Please see & support his work at [twitch.tv/crossproduct](https://twitch.tv/crossproduct).
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.7.3.
 
 ## Features
 
-* Ability to track via the mode. Do you dare take on Swordless Mode?
+* Ability to track via the starting state and sword logic. Do you dare take on Swordless Mode?
 * Ability to set the difficulty. No need to worry about accidentally setting the golden sword here.
 * Ability to set the goal. Do you want to take on all of the dungeons and bosses?
-* Ability to set the Keysanity item shuffle. Do you want to explore the land for keys?
+* Ability to set the different item shuffles. Do you want to explore the land for keys?
 * Ability to turn on a Go Mode indicator for when you can rush through dungeons.
 
 ### Planned Features

--- a/src/app/boss/boss.service.spec.ts
+++ b/src/app/boss/boss.service.spec.ts
@@ -7,7 +7,7 @@ import { WordSpacingPipe } from '../word-spacing.pipe';
 
 import { ItemKey } from '../items/item-key';
 
-import { Mode } from '../settings/mode';
+import { SwordLogic } from '../settings/sword-logic';
 
 import { Location } from '../dungeon/location';
 
@@ -27,7 +27,7 @@ describe( 'The boss service', () => {
   describe( 'when not in swordless mode', () => {
     beforeAll(() => {
       settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-      spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+      spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
 
       itemService = new ItemService(settingsService);
       bossService = new BossService(settingsService, itemService);
@@ -131,7 +131,7 @@ describe( 'The boss service', () => {
   describe( 'when in swordless mode', () => {
     beforeAll(() => {
       settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-      spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Swordless );
+      spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Swordless );
 
       itemService = new ItemService(settingsService);
       bossService = new BossService(settingsService, itemService);

--- a/src/app/boss/boss.service.ts
+++ b/src/app/boss/boss.service.ts
@@ -32,11 +32,8 @@ export class BossService {
   private _bossMap: Map<Location, () => boolean>;
 
   private canDefeatAgahnim(): boolean {
-    if ( this._items.net ) {
-      return true;
-    }
-
-    return this._items.hasPrimaryMelee();
+    return !!this._items.net || !!this._items.hammer
+      || this._items.hasSword();
   }
 
   private canDefeatArmosKnights(): boolean {

--- a/src/app/dungeon/dungeon.repository.ts
+++ b/src/app/dungeon/dungeon.repository.ts
@@ -134,7 +134,7 @@ export const Dungeons = new Map<Location, Dungeon>(
       'Ganon\'s Tower',
       'Agahnim 2',
       Reward.None,
-      0,
+      20,
       27,
       4
     )

--- a/src/app/go-mode/go-mode.service.spec.ts
+++ b/src/app/go-mode/go-mode.service.spec.ts
@@ -15,7 +15,7 @@ import { Location } from '../dungeon/location';
 import { ItemKey } from '../items/item-key';
 
 import { Goal } from '../settings/goal';
-import { Mode } from '../settings/mode';
+import { SwordLogic } from '../settings/sword-logic';
 import { Availability } from '../map/availability';
 import { settings } from 'cluster';
 
@@ -29,7 +29,7 @@ describe( 'The Go Mode service', () => {
 
   beforeAll(() => {
     settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-    spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Standard );
+    spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
   });
 
   function reset() {

--- a/src/app/guide/guide.component.html
+++ b/src/app/guide/guide.component.html
@@ -68,20 +68,35 @@
     </p>
     <h5>Settings</h5>
     <p>If the settings are confusing, the explanations are here.</p>
-    <h6>Mode</h6>
-    <p>This states the general mode of the game.</p>
+    <h6>Starting State</h6>
+    <p>This states how the beginning of the game goes.</p>
     <ul>
       <li>
         <strong>Standard</strong>
-        The standard opening of the game plays out. One sword is guaranteed.
+        The standard opening of the game plays out.
+        A weapon will be given to you by your uncle.
       </li>
       <li>
         <strong>Open</strong>
         The rainy intro is pre-done. You can start from Sanctuary. No sword is guaranteed.
       </li>
+    </ul>
+    <h6>Sword Logic</h6>
+    <p>This states where swords can be found.</p>
+    <ul>
+      <li>
+        <strong>Randomized</strong>
+        Swords can be found at any location that does not
+        require a sword to gain access.
+      </li>
+      <li>
+        <strong>Uncle Assured</strong>
+        Your uncle is guaranteed to have a sword.
+      </li>
       <li>
         <strong>Swordless</strong>
-        Open Mode, but without any swords at all! The hammer can be used against Ganon, at least.
+        There are no swords at all in the game!
+        The hammer can be used against Ganon, at least.
       </li>
     </ul>
     <h6>Goal</h6>

--- a/src/app/items/item.service.spec.ts
+++ b/src/app/items/item.service.spec.ts
@@ -5,7 +5,7 @@ import { LocalStorageService } from '../local-storage.service';
 import { WordSpacingPipe } from '../word-spacing.pipe';
 
 import { GlitchLogic } from '../settings/glitch-logic';
-import { Mode } from '../settings/mode';
+import { SwordLogic } from '../settings/sword-logic';
 import { Difficulty } from '../settings/difficulty';
 
 import { Sword } from './sword';
@@ -24,7 +24,7 @@ describe( 'The item service', () => {
   describe( '-- in swordless mode --', () => {
     beforeAll(() => {
       settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-      spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Swordless );
+      spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Swordless );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
     });
 
@@ -70,10 +70,10 @@ describe( 'The item service', () => {
     });
   });
 
-  describe( '-- in expert open mode --', () => {
+  describe( '-- in expert open uncle assured mode --', () => {
     beforeAll(() => {
       settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-      spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+      spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
       spyOn( settingsService, 'isExpertOrInsane' ).and.returnValue( true );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Expert );
     });
@@ -190,10 +190,10 @@ describe( 'The item service', () => {
     });
   });
 
-  describe( '-- in hard mode --', () => {
+  describe( '-- in hard randomized sword mode --', () => {
     beforeAll(() => {
       settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-      spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+      spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Hard );
     });
 

--- a/src/app/items/item.service.ts
+++ b/src/app/items/item.service.ts
@@ -601,4 +601,11 @@ export class ItemService {
 
     return this.hasGlove() && !!this.lantern;
   }
+
+  hasReliableWeapon(): boolean {
+    return this.hasMeleeOrBow()
+      || this.hasCane()
+      || !!this.fireRod
+      || !!this.bomb;
+  }
 }

--- a/src/app/map/dungeon-locations/dungeon-location.service.spec.ts
+++ b/src/app/map/dungeon-locations/dungeon-location.service.spec.ts
@@ -14,7 +14,7 @@ import { Location } from '../../dungeon/location';
 import { ItemKey } from '../../items/item-key';
 
 import { ItemShuffle } from '../../settings/item-shuffle';
-import { Mode } from '../../settings/mode';
+import { SwordLogic } from '../../settings/sword-logic';
 import { settings } from 'cluster';
 
 describe( 'The dungeon location service', () => {
@@ -26,7 +26,7 @@ describe( 'The dungeon location service', () => {
 
   beforeAll(() => {
     settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-    spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Standard );
+    spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
   });
 
   function reset() {
@@ -82,7 +82,7 @@ describe( 'The dungeon location service', () => {
         let tempService: DungeonLocationService;
 
         beforeEach( () => {
-          spyOnProperty(tempSettings, 'mode', 'get').and.returnValue(Mode.Swordless);
+          spyOnProperty(tempSettings, 'swordLogic', 'get').and.returnValue( SwordLogic.Swordless);
           tempService = new DungeonLocationService( itemService, dungeonService, tempSettings, bossService );
         });
 
@@ -96,17 +96,35 @@ describe( 'The dungeon location service', () => {
           expect( tempService.getChestAvailability(location)).toBe( Availability.Unavailable );
         });
 
-        it( 'can be beaten with the net, though is tricky without the lamp.', () => {
-          itemService.getItem(ItemKey.Cape).state = 1;
-          itemService.getItem(ItemKey.Net).state = 1;
+        it( 'can be beaten with the net and bow, though is tricky without the lamp.', () => {
+          itemService.setItemState(ItemKey.Bow, 1);
+          itemService.setItemState(ItemKey.Cape, 1);
+          itemService.setItemState(ItemKey.Net, 1);
 
           expect( tempService.getChestAvailability(location)).toBe( Availability.Glitches );
         });
 
-        it( 'can be beaten cleanly with the net and lantern.', () => {
+        it( 'can be beaten cleanly with the cape, lantern, and hammer.', () => {
+          itemService.setItemState( ItemKey.Cape, 1);
+          itemService.setItemState( ItemKey.Lantern, 1);
+          itemService.setItemState( ItemKey.Hammer, 1);
+
+          expect( tempService.getChestAvailability( location ) ).toBe( Availability.Available );
+        });
+
+        it( 'cannot be beaten cleanly with the net and lantern: trap rooms prevent death.', () => {
           itemService.getItem(ItemKey.Cape).state = 1;
           itemService.getItem(ItemKey.Net).state = 1;
           itemService.getItem(ItemKey.Lantern).state = 1;
+
+          expect( tempService.getChestAvailability(location)).toBe( Availability.Unavailable );
+        });
+
+        it( 'can be beaten cleanly with the net and lantern.', () => {
+          itemService.setItemState(ItemKey.Cape, 1);
+          itemService.setItemState(ItemKey.Net, 1);
+          itemService.setItemState(ItemKey.Bomb, 1);
+          itemService.setItemState(ItemKey.Lantern, 1);
 
           expect( tempService.getChestAvailability(location)).toBe( Availability.Available );
         });

--- a/src/app/map/dungeon-locations/dungeon-location.service.ts
+++ b/src/app/map/dungeon-locations/dungeon-location.service.ts
@@ -65,30 +65,23 @@ export class DungeonLocationService {
   private _chestAvailability: Map<Location, () => Availability>;
   private _dungeonLocations: Map<Location, DungeonLocation>;
 
-  private isCastleTowerSwordlessAvailable(): Availability {
-    if ( !(this._inventory.hammer || this._inventory.cape) ) {
-      return Availability.Unavailable;
-    }
-
-    if ( !this._inventory.net ) {
-      return Availability.Unavailable;
-    }
-
-    return this._inventory.lantern ? Availability.Available : Availability.Glitches;
-  }
-
   private isCastleTowerAvailable(): Availability {
-    if ( this._settings.isSwordless() ) {
-      return this.isCastleTowerSwordlessAvailable();
-    }
-
     const items = this._inventory;
 
-    const canEnter = items.cape || ( items.sword !== Sword.None && items.sword !== Sword.Wooden );
+    let canEnter = !!items.cape;
+    if ( !canEnter ) {
+      if ( this._settings.isSwordless() ) {
+        canEnter = !!items.hammer;
+      } else {
+        canEnter = items.sword !== Sword.None && items.sword !== Sword.Wooden;
+      }
+    }
+
+    const canNavigateDungeon = items.hasReliableWeapon();
 
     const canBeatAgahnim = this._boss.canDefeatBoss(Location.CastleTower);
 
-    if ( !canEnter || !canBeatAgahnim ) {
+    if ( !canEnter || !canNavigateDungeon || !canBeatAgahnim ) {
       return Availability.Unavailable;
     }
 

--- a/src/app/map/item-locations/item-location.service.spec.ts
+++ b/src/app/map/item-locations/item-location.service.spec.ts
@@ -12,7 +12,7 @@ import { ItemKey } from '../../items/item-key';
 import { WordSpacingPipe } from '../../word-spacing.pipe';
 
 import { Location } from '../../dungeon/location';
-import { Mode } from '../../settings/mode';
+import { StartState } from '../../settings/start-state';
 
 describe( 'The item location service', () => {
   let itemLocationService: ItemLocationService;
@@ -119,9 +119,9 @@ describe( 'The item location service', () => {
     const tempSettings = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
     let tempService: ItemLocationService;
 
-    describe( 'in open mode', () => {
+    describe( 'in the open start state', () => {
       beforeEach( () => {
-        spyOnProperty( tempSettings, 'mode', 'get').and.returnValue(Mode.Open);
+        spyOnProperty( tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
         tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
       });
 
@@ -131,9 +131,9 @@ describe( 'The item location service', () => {
       });
     });
 
-    describe( 'in standard mode', () => {
+    describe( 'in the standard start state', () => {
       beforeEach( () => {
-        spyOnProperty( tempSettings, 'mode', 'get').and.returnValue(Mode.Standard);
+        spyOnProperty( tempSettings, 'startState', 'get').and.returnValue(StartState.Standard);
         tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
       });
 
@@ -969,7 +969,7 @@ describe( 'The item location service', () => {
     let tempService: ItemLocationService;
 
     beforeEach( () => {
-      spyOnProperty(tempSettings, 'mode', 'get').and.returnValue(Mode.Open);
+      spyOnProperty(tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
       tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
     });
 
@@ -997,7 +997,7 @@ describe( 'The item location service', () => {
     let tempService: ItemLocationService;
 
     beforeEach( () => {
-      spyOnProperty(tempSettings, 'mode', 'get').and.returnValue(Mode.Open);
+      spyOnProperty(tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
       tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
     });
 

--- a/src/app/reset/reset.component.spec.ts
+++ b/src/app/reset/reset.component.spec.ts
@@ -15,7 +15,7 @@ import { BossService } from '../boss/boss.service';
 
 import { ItemKey } from '../items/item-key';
 
-import { Mode } from '../settings/mode';
+import { SwordLogic } from '../settings/sword-logic';
 import { Difficulty } from '../settings/difficulty';
 
 describe( 'The reset component', () => {
@@ -33,7 +33,7 @@ describe( 'The reset component', () => {
 
   beforeAll( () => {
     settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-    spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+    spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
 

--- a/src/app/settings/mode.ts
+++ b/src/app/settings/mode.ts
@@ -1,5 +1,0 @@
-export enum Mode {
-  Standard,
-  Open,
-  Swordless
-}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -8,15 +8,30 @@
   <div class="modal-body">
     <form>
       <div class="form-group">
-        <span class="label-header">Select your mode.</span>
+        <span class="label-header">Select your start state.</span>
         <ul>
-          <li *ngFor="let opt of options.modeKeys; let idx = index">
-            <label (click)="saveMode($event, idx)">
+          <li *ngFor="let opt of options.startStateKeys; let idx = index">
+            <label (click)="saveStartState($event, idx)">
               <input
                 type="radio"
-                name="stumpy-mode"
+                name="stumpy-start-state"
                 [value]="opt.value"
-                [checked]="idx === options.mode"
+                [checked]="idx === options.startState"
+              >{{opt.label}}
+            </label>
+          </li>
+        </ul>
+      </div>
+      <div class="form-group">
+        <span class="label-header">Select your sword logic.</span>
+        <ul>
+          <li *ngFor="let opt of options.swordLogicKeys; let idx = index">
+            <label (click)="saveSwordLogic($event, idx)">
+              <input
+                type="radio"
+                name="stumpy-sword-logic"
+                [value]="opt.value"
+                [checked]="idx === options.swordLogic"
               >{{opt.label}}
             </label>
           </li>

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -10,7 +10,7 @@ import { SettingsService } from './settings.service';
 import { WordSpacingPipe } from '../word-spacing.pipe';
 import { LocalStorageService } from '../local-storage.service';
 
-import { Mode } from './mode';
+import { SwordLogic } from './sword-logic';
 import { Difficulty } from './difficulty';
 
 describe( 'The settings component', () => {
@@ -25,7 +25,7 @@ describe( 'The settings component', () => {
 
   beforeAll( () => {
     settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-    spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+    spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
 

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -28,8 +28,12 @@ export class SettingsComponent implements OnInit {
     this._modalService.open( content );
   }
 
-  saveMode( evt: Event, value: any ): void {
-    this._options.mode = value;
+  saveStartState( evt: Event, value: any ): void {
+    this._options.startState = value;
+  }
+
+  saveSwordLogic( evt: Event, value: any ): void {
+    this._options.swordLogic = value;
   }
 
   saveGoal( evt: Event, value: any ): void {

--- a/src/app/settings/settings.service.spec.ts
+++ b/src/app/settings/settings.service.spec.ts
@@ -3,7 +3,7 @@ import { LocalStorageService } from '../local-storage.service';
 
 import { WordSpacingPipe } from '../word-spacing.pipe';
 
-import { Mode } from './mode';
+import { SwordLogic } from './sword-logic';
 import { GlitchLogic } from './glitch-logic';
 
 describe( 'The settings service', () => {
@@ -14,7 +14,7 @@ describe( 'The settings service', () => {
   });
 
   beforeEach(() => {
-    service.mode = Mode.Standard;
+    service.swordLogic = SwordLogic.Randomized;
 
     const store: any = {};
 
@@ -32,22 +32,23 @@ describe( 'The settings service', () => {
   });
 
   it( 'should start with default settings.', () => {
-    expect( service.mode ).toBe( Mode.Standard );
+    expect( service.swordLogic ).toBe( SwordLogic.Randomized );
     expect( service.logic ).toBe( GlitchLogic.None );
   });
 
   it( 'should save new settings, then load those settings between different instances of the service.', () => {
-    service.mode = Mode.Open;
+    service.swordLogic = SwordLogic.UncleAssured;
     service.logic = GlitchLogic.Overworld;
 
     const secondService = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
 
-    expect( secondService.mode ).toBe( service.mode );
+    expect( secondService.swordLogic ).toBe( service.swordLogic );
     expect( secondService.logic ).toBe( service.logic );
   });
 
   it( 'should get the correct number of drop down choices sucessfully for each option.', () => {
-    expect( service.modeKeys.length ).toBe( 3 );
+    expect( service.startStateKeys.length ).toBe( 2 );
+    expect( service.swordLogicKeys.length ).toBe( 3 );
     expect( service.logicKeys.length ).toBe( 3 );
     expect( service.showGoModeKeys.length ).toBe( 2 );
     expect( service.difficultyKeys.length ).toBe( 5 );

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -6,7 +6,8 @@ import { WordSpacingPipe } from '../word-spacing.pipe';
 import { Difficulty } from './difficulty';
 import { Goal } from './goal';
 import { ItemShuffle } from './item-shuffle';
-import { Mode } from './mode';
+import { StartState } from './start-state';
+import { SwordLogic } from './sword-logic';
 import { GlitchLogic } from './glitch-logic';
 import { Enemy } from './enemy';
 
@@ -25,10 +26,16 @@ export class SettingsService {
     private localStorageService: LocalStorageService,
     private wordSpacingPipe: WordSpacingPipe
   ) {
-    if ( !this.localStorageService.hasItem( 'mode' ) ) {
-      this.mode = Mode.Standard;
+    if ( !this.localStorageService.hasItem( 'startState' ) ) {
+      this.startState = StartState.Standard;
     } else {
-      this._mode = parseInt( localStorage.getItem( 'mode' ), 10 );
+      this._startState = parseInt( localStorage.getItem( 'startState'), 10 );
+    }
+
+    if ( !this.localStorageService.hasItem( 'swordLogic' ) ) {
+      this.swordLogic = SwordLogic.Randomized;
+    } else {
+      this._swordLogic = parseInt( localStorage.getItem( 'swordLogic' ), 10 );
     }
 
     if ( !this.localStorageService.hasItem( 'difficulty' ) ) {
@@ -68,7 +75,8 @@ export class SettingsService {
     }
   }
 
-  private _mode: Mode;
+  private _startState: StartState;
+  private _swordLogic: SwordLogic;
   private _logic: GlitchLogic;
   private _difficulty: Difficulty;
   private _showGoMode: number;
@@ -76,16 +84,28 @@ export class SettingsService {
   private _itemShuffle: ItemShuffle;
   private _enemy: Enemy;
 
-  get mode(): Mode {
-    return this._mode;
+  get startState(): StartState {
+    return this._startState;
   }
-  set mode(mode: Mode) {
-    this._mode = parseInt( mode + '', 10 );
-    this.localStorageService.setItem( 'mode', this.mode + '' );
+  set startState(startState: StartState) {
+    this._startState = parseInt( startState + '', 10 );
+    this.localStorageService.setItem( 'startState', this.startState + '' );
   }
 
-  get modeKeys(): any {
-    return this.getDropDownPairs( enumToArray(Mode));
+  get startStateKeys(): any {
+    return this.getDropDownPairs(enumToArray(StartState));
+  }
+
+  get swordLogic(): SwordLogic {
+    return this._swordLogic;
+  }
+  set swordLogic(swordLogic: SwordLogic) {
+    this._swordLogic = parseInt( swordLogic + '', 10 );
+    this.localStorageService.setItem( 'swordLogic', this.swordLogic + '' );
+  }
+
+  get swordLogicKeys(): any {
+    return this.getDropDownPairs(enumToArray(SwordLogic));
   }
 
   get difficulty(): Difficulty {
@@ -194,11 +214,11 @@ export class SettingsService {
   }
 
   isSwordless(): boolean {
-    return this.mode === Mode.Swordless;
+    return this.swordLogic === SwordLogic.Swordless;
   }
 
   isStandard(): boolean {
-    return this.mode === Mode.Standard;
+    return this.startState === StartState.Standard;
   }
 
   isKeysanity(): boolean {

--- a/src/app/settings/start-state.ts
+++ b/src/app/settings/start-state.ts
@@ -1,0 +1,4 @@
+export enum StartState {
+  Standard,
+  Open
+}

--- a/src/app/settings/sword-logic.ts
+++ b/src/app/settings/sword-logic.ts
@@ -1,0 +1,5 @@
+export enum SwordLogic {
+  Randomized,
+  UncleAssured,
+  Swordless
+}

--- a/src/app/tracker.component.spec.ts
+++ b/src/app/tracker.component.spec.ts
@@ -20,7 +20,7 @@ import { DungeonLocationService } from './map/dungeon-locations/dungeon-location
 import { CaptionService } from './caption/caption.service';
 import { BossService } from './boss/boss.service';
 
-import { Mode } from './settings/mode';
+import { SwordLogic } from './settings/sword-logic';
 import { Difficulty } from './settings/difficulty';
 
 import { WordSpacingPipe } from './word-spacing.pipe';
@@ -36,7 +36,7 @@ describe( 'The main tracking component', () => {
 
   beforeAll( () => {
     settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
-    spyOnProperty( settingsService, 'mode', 'get').and.returnValue( Mode.Open );
+    spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
 


### PR DESCRIPTION
* Add the starting state and sword logic enums.
* Remove the mode enum.
* Fix Castle Tower logic.
* Always show possible items on Ganon's Tower.