### PR TITLE
Crude 'save state'

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -25,6 +25,7 @@ import { CaptionService } from './caption/caption.service';
 
 import { WordSpacingPipe } from './word-spacing.pipe';
 import { CamelCasePipe } from './camel-case.pipe';
+import { SaveService } from './save.service';
 
 describe( 'The application component', () => {
   let comp: AppComponent;
@@ -62,7 +63,8 @@ describe( 'The application component', () => {
         {
           provide: ComponentFixtureAutoDetect,
           useValue: true
-        }
+        },
+        SaveService
       ]
     }).compileComponents();
   }));

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -24,6 +25,7 @@ import { RandomizerTrackerComponent } from './tracker.component';
 
 import { CamelCasePipe } from './camel-case.pipe';
 import { WordSpacingPipe } from './word-spacing.pipe';
+import { SaveService } from './save.service';
 
 @NgModule({
   declarations: [
@@ -52,7 +54,8 @@ import { WordSpacingPipe } from './word-spacing.pipe';
     DungeonLocationService,
     LocalStorageService,
     SettingsService,
-    BossService
+    BossService,
+    SaveService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/boss/boss.service.spec.ts
+++ b/src/app/boss/boss.service.spec.ts
@@ -10,14 +10,18 @@ import { ItemKey } from '../items/item-key';
 import { SwordLogic } from '../settings/sword-logic';
 
 import { Location } from '../dungeon/location';
+import { SaveService } from '../save.service';
 
 describe( 'The boss service', () => {
   let bossService: BossService;
   let itemService: ItemService;
   let settingsService: SettingsService;
+  let saveService: SaveService;
 
   function reset() {
-    itemService.reset();
+    if (itemService) {
+      itemService.reset();
+    }
   }
 
   function validate(location: Location, value: any) {
@@ -26,10 +30,11 @@ describe( 'The boss service', () => {
 
   describe( 'when not in swordless mode', () => {
     beforeAll(() => {
-      settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+      saveService = new SaveService();
+      settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
       spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
 
-      itemService = new ItemService(settingsService);
+      itemService = new ItemService(settingsService, saveService);
       bossService = new BossService(settingsService, itemService);
     });
 
@@ -130,10 +135,11 @@ describe( 'The boss service', () => {
 
   describe( 'when in swordless mode', () => {
     beforeAll(() => {
-      settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+      saveService = new SaveService();
+      settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
       spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Swordless );
 
-      itemService = new ItemService(settingsService);
+      itemService = new ItemService(settingsService, saveService);
       bossService = new BossService(settingsService, itemService);
     });
 

--- a/src/app/caption/caption.component.spec.ts
+++ b/src/app/caption/caption.component.spec.ts
@@ -3,6 +3,7 @@ import { DebugElement } from '@angular/core';
 import { CaptionService } from './caption.service';
 import { CaptionComponent } from './caption.component';
 import { TextToImage } from './text-to-image.pipe';
+import { SaveService } from '../save.service';
 
 describe( 'The caption component', () => {
   let comp: CaptionComponent;
@@ -14,7 +15,7 @@ describe( 'The caption component', () => {
   beforeEach( () => {
     TestBed.configureTestingModule({
       declarations: [CaptionComponent],
-      providers: [CaptionService, TextToImage]
+      providers: [CaptionService, TextToImage, SaveService]
     }).compileComponents();
 
     fixture = TestBed.createComponent( CaptionComponent );

--- a/src/app/dungeon/dungeon.component.spec.ts
+++ b/src/app/dungeon/dungeon.component.spec.ts
@@ -11,6 +11,7 @@ import { WordSpacingPipe } from '../word-spacing.pipe';
 import { Location } from './location';
 import { EntranceLock } from './entrance-lock';
 import { Reward } from './reward';
+import { SaveService } from '../save.service';
 
 describe( 'The dungeon component', () => {
   let comp: DungeonComponent;
@@ -29,7 +30,8 @@ describe( 'The dungeon component', () => {
         SettingsService,
         LocalStorageService,
         CamelCasePipe,
-        WordSpacingPipe
+        WordSpacingPipe,
+        SaveService
       ]
     }).compileComponents();
   }));

--- a/src/app/dungeon/dungeon.component.ts
+++ b/src/app/dungeon/dungeon.component.ts
@@ -121,6 +121,8 @@ export class DungeonComponent implements OnInit {
     }
 
     this.dungeon.cycleBossForward();
+
+    this.dungeonService.saveState();
   }
 
   whenBossRightClicked( evt: MouseEvent ) {
@@ -136,6 +138,8 @@ export class DungeonComponent implements OnInit {
     }
 
     this.dungeon.cycleBossBackward();
+
+    this.dungeonService.saveState();
   }
 
   whenChestClicked(evt: MouseEvent): void {
@@ -149,6 +153,8 @@ export class DungeonComponent implements OnInit {
     } else {
       this.dungeon.decrementItemChestCount();
     }
+
+    this.dungeonService.saveState();
   }
 
   whenRewardClicked(evt: MouseEvent): void {
@@ -156,6 +162,8 @@ export class DungeonComponent implements OnInit {
     evt.preventDefault();
 
     this.dungeon.cycleReward();
+
+    this.dungeonService.saveState();
   }
 
   whenMedallionClicked(evt: MouseEvent): void {
@@ -163,6 +171,8 @@ export class DungeonComponent implements OnInit {
     evt.preventDefault();
 
     this.dungeon.cycleEntranceLock();
+
+    this.dungeonService.saveState();
   }
 
   whenBigKeyClicked(evt: MouseEvent): void {
@@ -170,6 +180,8 @@ export class DungeonComponent implements OnInit {
     evt.preventDefault();
 
     this.dungeon.toggleBigKey();
+
+    this.dungeonService.saveState();
   }
 
   getBigKeyClasses(): any {
@@ -193,6 +205,8 @@ export class DungeonComponent implements OnInit {
     evt.preventDefault();
 
     this.dungeon.incrementSmallKeyCount();
+
+    this.dungeonService.saveState();
   }
 
   hasSmallKeys(): any {
@@ -208,6 +222,8 @@ export class DungeonComponent implements OnInit {
     evt.preventDefault();
 
     this.dungeon.toggleDefeat();
+
+    this.dungeonService.saveState();
   }
 
   getBossToggleClasses(): any {

--- a/src/app/go-mode/go-mode.service.spec.ts
+++ b/src/app/go-mode/go-mode.service.spec.ts
@@ -18,6 +18,7 @@ import { Goal } from '../settings/goal';
 import { SwordLogic } from '../settings/sword-logic';
 import { Availability } from '../map/availability';
 import { settings } from 'cluster';
+import { SaveService } from '../save.service';
 
 describe( 'The Go Mode service', () => {
   let dungeonLocationService: DungeonLocationService;
@@ -26,16 +27,18 @@ describe( 'The Go Mode service', () => {
   let settingsService: SettingsService;
   let goModeService: GoModeService;
   let bossService: BossService;
+  let saveService: SaveService;
 
   beforeAll(() => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    saveService = new SaveService();
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
     spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
   });
 
   function reset() {
-    itemService = new ItemService( settingsService );
+    itemService = new ItemService( settingsService, saveService );
     itemService.reset();
-    dungeonService = new DungeonService();
+    dungeonService = new DungeonService( saveService );
     dungeonService.reset();
     bossService = new BossService( settingsService, itemService );
     dungeonLocationService = new DungeonLocationService( itemService, dungeonService, settingsService, bossService );

--- a/src/app/items/item.component.spec.ts
+++ b/src/app/items/item.component.spec.ts
@@ -9,6 +9,7 @@ import { SettingsService } from '../settings/settings.service';
 import { LocalStorageService } from '../local-storage.service';
 
 import { ItemKey } from './item-key';
+import { SaveService } from '../save.service';
 
 describe( 'The item component', () => {
   let comp: ItemComponent;
@@ -37,7 +38,7 @@ describe( 'The item component', () => {
   beforeEach( async(() => {
     TestBed.configureTestingModule({
       declarations: [ItemComponent],
-      providers: [WordSpacingPipe, ItemService, SettingsService, LocalStorageService]
+      providers: [WordSpacingPipe, ItemService, SettingsService, LocalStorageService, SaveService]
     }).compileComponents();
   }));
 

--- a/src/app/items/item.component.ts
+++ b/src/app/items/item.component.ts
@@ -21,6 +21,8 @@ export class ItemComponent {
     evt.preventDefault();
 
     this._itemService.setItemState(this.itemId, this._itemService.getItem(this.itemId).state + 1);
+
+    this._itemService.saveState();
   }
 
   getClasses(): any {

--- a/src/app/items/item.service.spec.ts
+++ b/src/app/items/item.service.spec.ts
@@ -9,21 +9,23 @@ import { SwordLogic } from '../settings/sword-logic';
 import { Difficulty } from '../settings/difficulty';
 
 import { Sword } from './sword';
-import { Item } from './item';
 import { ItemKey } from './item-key';
+import { SaveService } from '../save.service';
 
 describe( 'The item service', () => {
   let itemService: ItemService;
   let settingsService: SettingsService;
+  let saveService: SaveService;
 
   function reset() {
-    itemService = new ItemService( settingsService );
+    saveService = new SaveService();
+    itemService = new ItemService( settingsService, saveService );
     itemService.reset();
   }
 
   describe( '-- in swordless mode --', () => {
     beforeAll(() => {
-      settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+      settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
       spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Swordless );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
     });
@@ -72,7 +74,7 @@ describe( 'The item service', () => {
 
   describe( '-- in expert open uncle assured mode --', () => {
     beforeAll(() => {
-      settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+      settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
       spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
       spyOn( settingsService, 'isExpertOrInsane' ).and.returnValue( true );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Expert );
@@ -192,7 +194,7 @@ describe( 'The item service', () => {
 
   describe( '-- in hard randomized sword mode --', () => {
     beforeAll(() => {
-      settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+      settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
       spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
       spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Hard );
     });

--- a/src/app/local-storage.service.ts
+++ b/src/app/local-storage.service.ts
@@ -6,12 +6,12 @@ export class LocalStorageService {
     return this.getItem( key ) !== null;
   }
 
-  getItem( key: string ): string {
-    return localStorage.getItem( key );
+  getItem<T = any>( key: string ): T {
+    return JSON.parse(localStorage.getItem( key ));
   }
 
-  setItem( key: string, value: string ): void {
-    localStorage.setItem( key, value );
+  setItem<T = any>( key: string, value: T ): void {
+    localStorage.setItem( key, JSON.stringify(value) );
   }
 
   removeItem( key: string ): void {

--- a/src/app/map/dungeon-locations/dungeon-location.component.spec.ts
+++ b/src/app/map/dungeon-locations/dungeon-location.component.spec.ts
@@ -12,6 +12,7 @@ import { SettingsService } from '../../settings/settings.service';
 import { LocalStorageService } from '../../local-storage.service';
 import { CaptionService } from '../../caption/caption.service';
 import { BossService } from '../../boss/boss.service';
+import { SaveService } from '../../save.service';
 
 describe( 'The dungeon item component', () => {
   let comp: DungeonLocationComponent;
@@ -49,7 +50,8 @@ describe( 'The dungeon item component', () => {
         DungeonService,
         SettingsService,
         LocalStorageService,
-        BossService
+        BossService,
+        SaveService
       ]
     }).compileComponents();
   }));

--- a/src/app/map/dungeon-locations/dungeon-location.service.spec.ts
+++ b/src/app/map/dungeon-locations/dungeon-location.service.spec.ts
@@ -14,6 +14,7 @@ import { ItemKey } from '../../items/item-key';
 
 import { ItemShuffle } from '../../settings/item-shuffle';
 import { SwordLogic } from '../../settings/sword-logic';
+import { SaveService } from '../../save.service';
 
 describe( 'The dungeon location service', () => {
   let dungeonLocationService: DungeonLocationService;
@@ -21,16 +22,18 @@ describe( 'The dungeon location service', () => {
   let dungeonService: DungeonService;
   let settingsService: SettingsService;
   let bossService: BossService;
+  let saveService: SaveService;
 
   beforeAll(() => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    saveService = new SaveService();
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
     spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.UncleAssured );
   });
 
   function reset() {
-    itemService = new ItemService( settingsService );
+    itemService = new ItemService( settingsService, saveService );
     itemService.reset();
-    dungeonService = new DungeonService();
+    dungeonService = new DungeonService( saveService );
     dungeonService.reset();
     bossService = new BossService( settingsService, itemService );
     dungeonLocationService = new DungeonLocationService( itemService, dungeonService, settingsService, bossService );
@@ -76,7 +79,7 @@ describe( 'The dungeon location service', () => {
       });
 
       describe( 'in swordless mode', () => {
-        const tempSettings = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
+        const tempSettings = new SettingsService( new SaveService(), new WordSpacingPipe() );
         let tempService: DungeonLocationService;
 
         beforeEach( () => {

--- a/src/app/map/item-locations/item-location.component.spec.ts
+++ b/src/app/map/item-locations/item-location.component.spec.ts
@@ -11,6 +11,7 @@ import { DungeonService } from '../../dungeon/dungeon.service';
 import { SettingsService } from '../../settings/settings.service';
 import { LocalStorageService } from '../../local-storage.service';
 import { CaptionService } from '../../caption/caption.service';
+import { SaveService } from '../../save.service';
 
 describe( 'The item location component', () => {
   let comp: ItemLocationComponent;
@@ -47,7 +48,8 @@ describe( 'The item location component', () => {
         ItemService,
         DungeonService,
         SettingsService,
-        LocalStorageService
+        LocalStorageService,
+        SaveService
       ]
     }).compileComponents();
   }));

--- a/src/app/map/item-locations/item-location.component.ts
+++ b/src/app/map/item-locations/item-location.component.ts
@@ -36,6 +36,8 @@ export class ItemLocationComponent implements OnInit {
 
     if ( this._itemLocationService.canToggleOpened(this.itemLocationId)) {
       this.itemLocation.toggleOpened();
+
+      this._itemLocationService.saveState();
     }
   }
 

--- a/src/app/map/item-locations/item-location.service.spec.ts
+++ b/src/app/map/item-locations/item-location.service.spec.ts
@@ -4,7 +4,6 @@ import { DungeonService } from '../../dungeon/dungeon.service';
 import { SettingsService } from '../../settings/settings.service';
 import { LocalStorageService } from '../../local-storage.service';
 
-import { ItemLocation } from './item-location';
 import { Availability } from '../availability';
 import { LocationKey } from './location-key';
 import { ItemKey } from '../../items/item-key';
@@ -13,23 +12,26 @@ import { WordSpacingPipe } from '../../word-spacing.pipe';
 
 import { Location } from '../../dungeon/location';
 import { StartState } from '../../settings/start-state';
+import { SaveService } from '../../save.service';
 
 describe( 'The item location service', () => {
   let itemLocationService: ItemLocationService;
   let itemService: ItemService;
   let dungeonService: DungeonService;
   let settingsService: SettingsService;
+  let saveService: SaveService;
 
   beforeAll(() => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    saveService = new SaveService();
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
   });
 
   beforeEach( () => {
-    itemService = new ItemService( settingsService );
+    itemService = new ItemService( settingsService, saveService );
     itemService.reset();
-    dungeonService = new DungeonService();
+    dungeonService = new DungeonService( saveService );
     dungeonService.reset();
-    itemLocationService = new ItemLocationService( itemService, dungeonService, settingsService );
+    itemLocationService = new ItemLocationService( itemService, dungeonService, settingsService, saveService );
     itemLocationService.reset();
   });
 
@@ -116,13 +118,13 @@ describe( 'The item location service', () => {
 
   describe( 'set to Link\'s house', () => {
     const location = LocationKey.LinksHouse;
-    const tempSettings = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
+    const tempSettings = new SettingsService( new SaveService(), new WordSpacingPipe() );
     let tempService: ItemLocationService;
 
     describe( 'in the open start state', () => {
       beforeEach( () => {
         spyOnProperty( tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
-        tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
+        tempService = new ItemLocationService( itemService, dungeonService, tempSettings, saveService );
       });
 
       it( 'starts off as available.', () => {
@@ -134,7 +136,7 @@ describe( 'The item location service', () => {
     describe( 'in the standard start state', () => {
       beforeEach( () => {
         spyOnProperty( tempSettings, 'startState', 'get').and.returnValue(StartState.Standard);
-        tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
+        tempService = new ItemLocationService( itemService, dungeonService, tempSettings, saveService );
       });
 
       xit( 'starts off as claimed.', () => {
@@ -965,12 +967,12 @@ describe( 'The item location service', () => {
 
   describe( 'set to the three chests in the side of the escape', () => {
     const location = LocationKey.SewerEscapeSideRoom;
-    const tempSettings = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
+    const tempSettings = new SettingsService( new SaveService(), new WordSpacingPipe() );
     let tempService: ItemLocationService;
 
     beforeEach( () => {
       spyOnProperty(tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
-      tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
+      tempService = new ItemLocationService( itemService, dungeonService, tempSettings, saveService );
     });
 
     it( 'starts off as unavailable since boots and bombs are required.', () => {
@@ -993,12 +995,12 @@ describe( 'The item location service', () => {
 
   describe( 'set to the lone chest in the dark of the sewer escape', () => {
     const location = LocationKey.SewerEscapeDarkRoom;
-    const tempSettings = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
+    const tempSettings = new SettingsService( new SaveService(), new WordSpacingPipe() );
     let tempService: ItemLocationService;
 
     beforeEach( () => {
       spyOnProperty(tempSettings, 'startState', 'get').and.returnValue(StartState.Open);
-      tempService = new ItemLocationService( itemService, dungeonService, tempSettings );
+      tempService = new ItemLocationService( itemService, dungeonService, tempSettings, saveService );
     });
 
     it( 'starts off as available through skipping the lantern.', () => {

--- a/src/app/map/world/world.component.spec.ts
+++ b/src/app/map/world/world.component.spec.ts
@@ -15,6 +15,7 @@ import { DungeonService } from '../../dungeon/dungeon.service';
 import { ItemLocationService } from '../item-locations/item-location.service';
 import { DungeonLocationService } from '../dungeon-locations/dungeon-location.service';
 import { BossService } from '../../boss/boss.service';
+import { SaveService } from '../../save.service';
 
 describe( 'The world component', () => {
   let comp: WorldComponent;
@@ -35,7 +36,8 @@ describe( 'The world component', () => {
         DungeonService,
         ItemLocationService,
         DungeonLocationService,
-        BossService
+        BossService,
+        SaveService
       ]
     }).compileComponents();
 

--- a/src/app/reset/reset.component.spec.ts
+++ b/src/app/reset/reset.component.spec.ts
@@ -17,6 +17,7 @@ import { ItemKey } from '../items/item-key';
 
 import { SwordLogic } from '../settings/sword-logic';
 import { Difficulty } from '../settings/difficulty';
+import { SaveService } from '../save.service';
 
 describe( 'The reset component', () => {
   let comp: ResetComponent;
@@ -32,7 +33,7 @@ describe( 'The reset component', () => {
   let dungeonLocationService: DungeonLocationService;
 
   beforeAll( () => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
     spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
@@ -49,7 +50,8 @@ describe( 'The reset component', () => {
         DungeonService,
         ItemLocationService,
         DungeonLocationService,
-        BossService
+        BossService,
+        SaveService
       ]
     }).compileComponents();
 

--- a/src/app/reset/reset.component.ts
+++ b/src/app/reset/reset.component.ts
@@ -4,6 +4,7 @@ import { ItemService } from '../items/item.service';
 import { ItemLocationService } from '../map/item-locations/item-location.service';
 import { DungeonService } from '../dungeon/dungeon.service';
 import { DungeonLocationService } from '../map/dungeon-locations/dungeon-location.service';
+import { SaveService } from '../save.service';
 
 @Component( {
   providers: [],
@@ -17,7 +18,8 @@ export class ResetComponent {
     private _itemService: ItemService,
     private _itemLocationService: ItemLocationService,
     private _dungeonService: DungeonService,
-    private _dungeonLocationService: DungeonLocationService
+    private _dungeonLocationService: DungeonLocationService,
+    private _saveService: SaveService
   ) {}
 
   whenClicked(evt: MouseEvent): void {
@@ -28,5 +30,6 @@ export class ResetComponent {
     this._itemLocationService.reset();
     this._dungeonService.reset();
     this._dungeonLocationService.reset();
+    this._saveService.reset();
   }
 }

--- a/src/app/save.service.spec.ts
+++ b/src/app/save.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { SaveService } from './save.service';
+
+describe('SaveService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SaveService]
+    });
+  });
+
+  it('should be created', inject([SaveService], (service: SaveService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/save.service.ts
+++ b/src/app/save.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+
+export enum SaveKey {
+  Items = 'items',
+  Dungeons = 'dungeons',
+  ItemLocations = 'item-locations',
+  StartState = 'start-state',
+  SwordLogic = 'sword-logic',
+  Difficulty = 'difficulty',
+  Logic = 'logic',
+  ShowGoMode = 'show-go-mode',
+  Goal = 'goal',
+  ItemShuffle = 'item-shuffle',
+  Enemy = 'enemy',
+}
+
+@Injectable()
+export class SaveService {
+  save<T = any>(key: SaveKey, data: T): void {
+    // URLSearchParams does not support IE
+    const queryParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+    queryParams.set(key, JSON.stringify(data));
+
+    window.history.replaceState(null, null, `?${queryParams.toString().replace(/%2C/g, ',')}`);
+  }
+
+  restore<T = any>(key: SaveKey, defaultValue = null): T {
+    const queryParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+    const queryParam: string = queryParams.get(key);
+
+    return queryParam ? JSON.parse(queryParam) : defaultValue;
+  }
+
+  has(key: SaveKey): boolean {
+    const queryParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+    return !!queryParams.get(key);
+  }
+
+  reset(): void {
+    window.history.replaceState(null, null, '/');
+  }
+}

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -12,6 +12,7 @@ import { LocalStorageService } from '../local-storage.service';
 
 import { SwordLogic } from './sword-logic';
 import { Difficulty } from './difficulty';
+import { SaveService } from '../save.service';
 
 describe( 'The settings component', () => {
   let comp: SettingsComponent;
@@ -24,7 +25,7 @@ describe( 'The settings component', () => {
 //  let modalRef: NgbModalRef;
 
   beforeAll( () => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
     spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
@@ -36,7 +37,8 @@ describe( 'The settings component', () => {
         NgbModal,
         WordSpacingPipe,
         LocalStorageService,
-        SettingsService
+        SettingsService,
+        SaveService
       ],
       imports: [NgbModule.forRoot(), FormsModule]
     }).compileComponents();

--- a/src/app/settings/settings.service.spec.ts
+++ b/src/app/settings/settings.service.spec.ts
@@ -1,35 +1,21 @@
 import { SettingsService } from './settings.service';
-import { LocalStorageService } from '../local-storage.service';
 
 import { WordSpacingPipe } from '../word-spacing.pipe';
 
 import { SwordLogic } from './sword-logic';
 import { GlitchLogic } from './glitch-logic';
+import { SaveService } from '../save.service';
 
 describe( 'The settings service', () => {
   let service: SettingsService;
 
   beforeAll(() => {
-    service = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    service = new SettingsService( new SaveService(), new WordSpacingPipe() );
   });
 
   beforeEach(() => {
     service.swordLogic = SwordLogic.Randomized;
     service.logic = GlitchLogic.None;
-
-    const store: any = {};
-
-    spyOn( localStorage, 'getItem' ).and.callFake( (key: string): string => {
-      return store[key] || null;
-    });
-
-    spyOn( localStorage, 'removeItem' ).and.callFake( (key: string): void => {
-      delete store[key];
-    });
-
-    spyOn( localStorage, 'setItem' ).and.callFake( (key: string, value: string): void => {
-      store[key] = value;
-    });
   });
 
   it( 'should start with default settings.', () => {
@@ -41,7 +27,7 @@ describe( 'The settings service', () => {
     service.swordLogic = SwordLogic.UncleAssured;
     service.logic = GlitchLogic.Overworld;
 
-    const secondService = new SettingsService(new LocalStorageService(), new WordSpacingPipe() );
+    const secondService = new SettingsService(new SaveService(), new WordSpacingPipe() );
 
     expect( secondService.swordLogic ).toBe( service.swordLogic );
     expect( secondService.logic ).toBe( service.logic );

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 
-import { LocalStorageService } from '../local-storage.service';
 import { WordSpacingPipe } from '../word-spacing.pipe';
 
 import { Difficulty } from './difficulty';
@@ -10,6 +9,7 @@ import { StartState } from './start-state';
 import { SwordLogic } from './sword-logic';
 import { GlitchLogic } from './glitch-logic';
 import { Enemy } from './enemy';
+import { SaveKey, SaveService } from '../save.service';
 
 interface EnumItem<E> {
   value: E;
@@ -23,55 +23,55 @@ function enumToArray<E>(Enum: any): EnumItem<E>[] {
 @Injectable()
 export class SettingsService {
   constructor(
-    private localStorageService: LocalStorageService,
+    private saveService: SaveService,
     private wordSpacingPipe: WordSpacingPipe
   ) {
-    if ( !this.localStorageService.hasItem( 'startState' ) ) {
+    if ( !this.saveService.has( SaveKey.StartState ) ) {
       this.startState = StartState.Standard;
     } else {
-      this._startState = parseInt( localStorage.getItem( 'startState'), 10 );
+      this._startState = parseInt( saveService.restore( SaveKey.StartState), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'swordLogic' ) ) {
+    if ( !this.saveService.has( SaveKey.SwordLogic ) ) {
       this.swordLogic = SwordLogic.Randomized;
     } else {
-      this._swordLogic = parseInt( localStorage.getItem( 'swordLogic' ), 10 );
+      this._swordLogic = parseInt( saveService.restore( SaveKey.SwordLogic ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'difficulty' ) ) {
+    if ( !this.saveService.has( SaveKey.Difficulty ) ) {
       this.difficulty = Difficulty.Normal;
     } else {
-      this._difficulty = parseInt( localStorage.getItem( 'difficulty' ), 10 );
+      this._difficulty = parseInt( saveService.restore( SaveKey.Difficulty ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'logic' ) ) {
+    if ( !this.saveService.has( SaveKey.Logic ) ) {
       this.logic = GlitchLogic.None;
     } else {
-      this._logic = parseInt( localStorage.getItem( 'logic' ), 10 );
+      this._logic = parseInt( saveService.restore( SaveKey.Logic ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'showGoMode' ) ) {
+    if ( !this.saveService.has( SaveKey.ShowGoMode ) ) {
       this.showGoMode = 0;
     } else {
-      this._showGoMode = parseInt( localStorage.getItem( 'showGoMode' ), 10 );
+      this._showGoMode = parseInt( saveService.restore( SaveKey.ShowGoMode ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'goal' ) ) {
+    if ( !this.saveService.has( SaveKey.Goal ) ) {
       this.goal = Goal.Ganon;
     } else {
-      this._goal = parseInt( localStorage.getItem( 'goal' ), 10 );
+      this._goal = parseInt( saveService.restore( SaveKey.Goal ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'itemShuffle' ) ) {
+    if ( !this.saveService.has( SaveKey.ItemShuffle ) ) {
       this.itemShuffle = ItemShuffle.Normal;
     } else {
-      this._itemShuffle = parseInt( localStorage.getItem( 'itemShuffle' ), 10 );
+      this._itemShuffle = parseInt( saveService.restore( SaveKey.ItemShuffle ), 10 );
     }
 
-    if ( !this.localStorageService.hasItem( 'enemy' ) ) {
+    if ( !this.saveService.has( SaveKey.Enemy ) ) {
       this.enemy = Enemy.Normal;
     } else {
-      this._enemy = parseInt( localStorage.getItem( 'enemy' ) , 10 );
+      this._enemy = parseInt( saveService.restore( SaveKey.Enemy ) , 10 );
     }
   }
 
@@ -89,7 +89,7 @@ export class SettingsService {
   }
   set startState(startState: StartState) {
     this._startState = parseInt( startState + '', 10 );
-    this.localStorageService.setItem( 'startState', this.startState + '' );
+    this.saveService.save( SaveKey.StartState, this.startState );
   }
 
   get startStateKeys(): any {
@@ -101,7 +101,7 @@ export class SettingsService {
   }
   set swordLogic(swordLogic: SwordLogic) {
     this._swordLogic = parseInt( swordLogic + '', 10 );
-    this.localStorageService.setItem( 'swordLogic', this.swordLogic + '' );
+    this.saveService.save( SaveKey.SwordLogic, this.swordLogic );
   }
 
   get swordLogicKeys(): any {
@@ -113,7 +113,7 @@ export class SettingsService {
   }
   set difficulty(difficulty: Difficulty) {
     this._difficulty = parseInt( difficulty + '', 10 );
-    this.localStorageService.setItem( 'difficulty', this.difficulty + '' );
+    this.saveService.save( SaveKey.Difficulty, this.difficulty );
   }
 
   get difficultyKeys(): any {
@@ -125,7 +125,7 @@ export class SettingsService {
   }
   set logic(logic: GlitchLogic) {
     this._logic = parseInt( logic + '', 10 );
-    this.localStorageService.setItem( 'logic', this.logic + '' );
+    this.saveService.save( SaveKey.Logic, this.logic );
   }
 
   get logicKeys(): any {
@@ -137,7 +137,7 @@ export class SettingsService {
   }
   set showGoMode(goMode: number) {
     this._showGoMode = goMode;
-    this.localStorageService.setItem( 'showGoMode', this.showGoMode + '' );
+    this.saveService.save( SaveKey.ShowGoMode, this.showGoMode );
   }
 
   get showGoModeKeys(): any {
@@ -153,7 +153,7 @@ export class SettingsService {
   }
   set goal(goal: Goal) {
     this._goal = parseInt( goal + '', 10 );
-    this.localStorageService.setItem( 'goal', this.goal + '' );
+    this.saveService.save( SaveKey.Goal, this.goal );
   }
 
   get goalKeys(): any {
@@ -165,7 +165,7 @@ export class SettingsService {
   }
   set itemShuffle(itemShuffle: ItemShuffle) {
     this._itemShuffle = parseInt( itemShuffle + '', 10 );
-    this.localStorageService.setItem( 'itemShuffle', this.itemShuffle + '' );
+    this.saveService.save( SaveKey.ItemShuffle, this.itemShuffle );
   }
 
   get itemShuffleKeys(): any {
@@ -177,7 +177,7 @@ export class SettingsService {
   }
   set enemy(enemy: Enemy) {
     this._enemy = parseInt( enemy + '', 10 );
-    this.localStorageService.setItem( 'enemy', this.enemy + '' );
+    this.saveService.save( SaveKey.Enemy, this.enemy );
   }
 
   get enemyKeys(): any {

--- a/src/app/tracker.component.spec.ts
+++ b/src/app/tracker.component.spec.ts
@@ -25,6 +25,7 @@ import { Difficulty } from './settings/difficulty';
 
 import { WordSpacingPipe } from './word-spacing.pipe';
 import { CamelCasePipe } from './camel-case.pipe';
+import { SaveService } from './save.service';
 
 describe( 'The main tracking component', () => {
   let comp: RandomizerTrackerComponent;
@@ -35,7 +36,7 @@ describe( 'The main tracking component', () => {
   let settingsService: SettingsService;
 
   beforeAll( () => {
-    settingsService = new SettingsService( new LocalStorageService(), new WordSpacingPipe() );
+    settingsService = new SettingsService( new SaveService(), new WordSpacingPipe() );
     spyOnProperty( settingsService, 'swordLogic', 'get').and.returnValue( SwordLogic.Randomized );
     spyOnProperty( settingsService, 'difficulty', 'get').and.returnValue( Difficulty.Normal );
   });
@@ -55,7 +56,8 @@ describe( 'The main tracking component', () => {
         ItemLocationService,
         DungeonLocationService,
         CaptionService,
-        BossService
+        BossService,
+        SaveService
       ],
       imports: [
         NgbModule.forRoot(),


### PR DESCRIPTION
As noted, it's fairly crude in the fact that it assumes enum order won't change, but with it, we get a relatively compact way to save the state so it can be serialized into query parameters.

Any time you make a change, it will update the the URL (replacing state as opposed to pushing a new one). You can now safely refresh the browser, or share the link with someone else. It should also survive browser restarts and tab close/re-openings, it's bookmarkable and will survive clearing local cache, etc.

This is the max length the query parameters would be (632 characters, including the `?`):

https://localhost:4200?startState=0&swordLogic=0&difficulty=1&logic=0&showGoMode=0&goal=0&itemShuffle=0&enemy=1&start-state=1&sword-logic=1&show-go-mode=1&item-shuffle=1&items=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,-1,0]&dungeons=[[0,2,0,0,0,0,2,0,0],[3,6,1,0,0,0,3,1,0],[2,6,2,0,0,0,3,1,0],[2,6,3,0,0,0,3,1,0],[5,14,6,1,0,0,11,1,0],[6,10,5,0,0,0,7,1,0],[2,8,6,0,0,0,5,1,0],[4,8,7,0,0,0,5,1,0],[3,8,8,1,1,0,5,1,0],[2,6,9,0,0,0,5,1,1],[5,12,10,0,0,0,9,1,1],[20,27,11,0,0,0,24,0,0]]&item-locations=[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]

It aint pretty, but using a URL over the local storage allows you to have multiple states (i.e. maybe you start a 2nd random seed before you finished the first, but can keep both progresses separate) and to share and transfer states to other users/browsers. Hitting `Reset` clears the query params.

It would also invalidate the URL if we changed any of the enums related to items, dungeons or item locations.

I tried my best to follow you styles and such, and made sure all the tests passed.